### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/linear/LinearConnection.java
+++ b/src/main/java/io/kestra/plugin/linear/LinearConnection.java
@@ -39,6 +39,7 @@ public abstract class LinearConnection extends Task {
         description = "Full Authorization header value for Linear (usually the personal API key). Treat as secret and supply any needed prefix such as `Bearer ` yourself."
     )
     @PluginProperty(group = "connection", secret = true)
+    @ToString.Exclude
     private Property<String> token;
 
     protected HttpResponse<String> makeCall(RunContext runContext, String query) throws IllegalVariableEvaluationException {


### PR DESCRIPTION
## Summary

Remediates all findings (CRITICAL/HIGH/MEDIUM/LOW) from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** — API token included in Lombok `@ToString` output — `src/main/java/io/kestra/plugin/linear/LinearConnection.java:42` — Added `@ToString.Exclude` to the `token` field so the Linear API token is no longer emitted in plaintext via the Lombok-generated `toString()` (CWE-312, CWE-532, OWASP ASVS 2.10.4).

No MEDIUM or LOW findings were reported in the audit EPIC.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-linear/issues/73
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
